### PR TITLE
Publishing problem fix

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
+          scope: "@aiwizo"
       - run: npm ci
       - run: npm run build
       - run: npm publish --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,9 +28,8 @@ jobs:
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
-          scope: "@aiwizo"
       - run: npm ci
       - run: npm run build
       - run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN_READ_PUBLISH}}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ import FileUpload from "@aiwizo/react-file-upload";
   // Amount of parallell file uploads.
   // Defaults to 1.
   requestBatchSize={1}
+  // Calls this function with the
+  // data returned from the upload request
+  // of a file
+  onRowClick={(fileResponseData) => {
+    // Do something with the data from the file upload response
+  }}
 />
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@aiwizo/react-file-upload",
+  "name": "react-file-upload",
   "version": "0.2.0",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-file-upload",
+  "name": "@aiwizo/react-file-upload",
   "version": "0.2.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Trying to figure out how to configure the workflow to publish to npm.
The current setup works locally on my machine for running `npm publish --access public`
Running it with github actions gives 404 from the npm registry.